### PR TITLE
Fix api call which retrieves ticket activities

### DIFF
--- a/app/controllers/hipchat_controller.rb
+++ b/app/controllers/hipchat_controller.rb
@@ -80,7 +80,7 @@ class HipchatController < ApplicationController
 		end
 
 		def get_ticket_activities(id,domain,api_key)
-			site = RestClient::Resource.new("#{domain}/helpdesk/tickets/activities/#{id}.json",api_key,"X")
+			site = RestClient::Resource.new("#{domain}/helpdesk/tickets/#{id}/activities.json",api_key,"X")
 			response = site.get(:content_type=>"application/json")
 			return JSON.parse(response.body)
 		end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,6 @@
   <title>Hipchat</title>
 	<%= stylesheet_link_tag "boots.css" %>
   <%= stylesheet_link_tag "hipchat.css" %>
-  <%= javascript_include_tag "default" %>
   <%= javascript_include_tag 'jquery', 'application' %>
   
 </head>


### PR DESCRIPTION
Fix the api call in get_tickets_activities subroutine and remove a non existent js file.

Signed-off-by: Shreyas <shreyas.ns@freshdesk.com>